### PR TITLE
changed GoogleProvider

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -68,9 +68,31 @@ export const authOptions = {
 		GoogleProvider({
 			clientId: process.env.GOOGLE_ID,
 			clientSecret: process.env.GOOGLE_SECRET,
+			authorization: {
+				params: {
+					prompt: 'consent',
+					access_type: 'offline',
+					response_type: 'code',
+				},
+			},
+			checks: 'pkce',
 		}),
 		// ...add more providers here
 	],
-	secret: process.env.NEXTAUTH_SECRET,
+	secret: process.env.NEXT_AUTH_SECRET,
+	callbacks: {
+		async jwt({ token, account }) {
+			// Persist the OAuth access_token to the token right after signin
+			if (account) {
+				token.accessToken = account.access_token;
+			}
+			return token;
+		},
+		async session({ session, token, user }) {
+			// Send properties to the client, like an access_token from a provider.
+			session.accessToken = token.accessToken;
+			return session;
+		},
+	},
 };
 export default NextAuth(authOptions);


### PR DESCRIPTION
changed checks from ['state', 'pkce'] to ['pkce']. An error kept occurring after Google redirect with an response error of "checks.state is missing"